### PR TITLE
refactor ReturnOperation

### DIFF
--- a/php/v2/ReturnOperation.php
+++ b/php/v2/ReturnOperation.php
@@ -7,14 +7,30 @@ class TsReturnOperation extends ReferencesOperation
     public const TYPE_NEW    = 1;
     public const TYPE_CHANGE = 2;
 
+    public Seller $reseller;
+    public int $notificationType = 0;
+    public NotificationData $data;
+    protected $templateData = [];
+
     /**
+     * В данном случае реализация паттерна Command (Operation) целью которого является сделать
+     * непрямым взаимодействие исполнителя (MessagesClient и NotificationManager) и вызывающего класса (контроллера)
+     * Реализовано не полностью тк :
+     * - исполнитель лезет в данные запроса Request (а значит привязан к слою контроллера), а также в нем есть HTTP коды,
+     * которые могут иметь какое-то значение только в рамках http, лучше кидать эксепшены бизнес-логики, 
+     * уже в слое контроллер их преобразовывать для ответа клииенту, текущее решение снижает гибкость использования операции 
+     * то есть например осуществить данную операцию из командной строки уже невозможно (исправлено)
+     * - происходит два разных действия с точки зрения бизнеса (Админское уведомление и Клиентское уведомление), что странно (не исправлено)
+     * И есть некоторые вопросы, оставшиеся неисправленными
+     * - надо бы валидацию данных (not found for example) унести в контроллер, здесь оставить только бизнес-проверки
+     *  - что надо делать если одному админу письмо ушло, а на втором упало, надо ли слать клиенту
      * @throws \Exception
      */
-    public function doOperation(): void
+    public function doOperation(): array
     {
-        $data = (array)$this->getRequest('data');
-        $resellerId = $data['resellerId'];
-        $notificationType = (int)$data['notificationType'];
+        if ($this->notificationType == 0  || !in_array($this->notificationType, [self::TYPE_CHANGE, self::TYPE_NEW]) ) {
+            throw new BusinessException('Empty notificationType');
+        }
         $result = [
             'notificationEmployeeByEmail' => false,
             'notificationClientByEmail'   => false,
@@ -23,117 +39,127 @@ class TsReturnOperation extends ReferencesOperation
                 'message' => '',
             ],
         ];
-
-        if (empty((int)$resellerId)) {
-            $result['notificationClientBySms']['message'] = 'Empty resellerId';
-            return $result;
+        if (empty($this->reseller)) {
+            throw new BusinessException('Empty resellerId!');
         }
 
-        if (empty((int)$notificationType)) {
-            throw new \Exception('Empty notificationType', 400);
+        // Эта операция должна пройти в контроллере при валидации данных
+        // $reseller = Seller::getById((int)$resellerId);
+        // if ($reseller === null) {
+        //     throw new \Exception('Seller not found!', 400);
+        // }
+
+        $client = Contractor::getById($this->data->clientId);
+        if (
+            $client === null
+            || $client->type !== Contractor::TYPE_CUSTOMER
+            || ($client->Seller && $client->Seller->id !== $this->reseller->id)
+            ) {
+            throw new BusinessException('сlient not found!');
         }
 
-        $reseller = Seller::getById((int)$resellerId);
-        if ($reseller === null) {
-            throw new \Exception('Seller not found!', 400);
-        }
-
-        $client = Contractor::getById((int)$data['clientId']);
-        if ($client === null || $client->type !== Contractor::TYPE_CUSTOMER || $client->Seller->id !== $resellerId) {
-            throw new \Exception('сlient not found!', 400);
-        }
-
-        $cFullName = $client->getFullName();
-        if (empty($client->getFullName())) {
-            $cFullName = $client->name;
-        }
-
-        $cr = Employee::getById((int)$data['creatorId']);
+        $cr = Employee::getById($this->data->creatorId);
         if ($cr === null) {
-            throw new \Exception('Creator not found!', 400);
+            throw new BusinessException('Creator not found!');
         }
 
-        $et = Employee::getById((int)$data['expertId']);
-        if ($et === null) {
-            throw new \Exception('Expert not found!', 400);
+        $expert = Employee::getById($this->data->expertId);
+        if ($expert === null) {
+            throw new BusinessException('Expert not found!');
         }
 
         $differences = '';
-        if ($notificationType === self::TYPE_NEW) {
-            $differences = __('NewPositionAdded', null, $resellerId);
-        } elseif ($notificationType === self::TYPE_CHANGE && !empty($data['differences'])) {
-            $differences = __('PositionStatusHasChanged', [
-                    'FROM' => Status::getName((int)$data['differences']['from']),
-                    'TO'   => Status::getName((int)$data['differences']['to']),
-                ], $resellerId);
+        if ($this->notificationType === self::TYPE_NEW) {
+            $differences = ResellerView::make('NewPositionAdded', null, $this->reseller->id);
+        } elseif ($this->notificationType === self::TYPE_CHANGE && !empty($data['differences'])) {
+            $differences = ResellerView::make('PositionStatusHasChanged', [
+                    'FROM' => Status::getName($this->data->differencesFrom),
+                    'TO'   => Status::getName($this->data->differencesTo),
+                ], $this->reseller->id);
         }
 
-        $templateData = [
-            'COMPLAINT_ID'       => (int)$data['complaintId'],
-            'COMPLAINT_NUMBER'   => (string)$data['complaintNumber'],
-            'CREATOR_ID'         => (int)$data['creatorId'],
+        $this->templateData = [
+            'COMPLAINT_ID'       => $this->data->complaintId,
+            'COMPLAINT_NUMBER'   => $this->data->complaintNumber,
+            'CREATOR_ID'         => $cr->id,
             'CREATOR_NAME'       => $cr->getFullName(),
-            'EXPERT_ID'          => (int)$data['expertId'],
-            'EXPERT_NAME'        => $et->getFullName(),
-            'CLIENT_ID'          => (int)$data['clientId'],
-            'CLIENT_NAME'        => $cFullName,
-            'CONSUMPTION_ID'     => (int)$data['consumptionId'],
-            'CONSUMPTION_NUMBER' => (string)$data['consumptionNumber'],
-            'AGREEMENT_NUMBER'   => (string)$data['agreementNumber'],
-            'DATE'               => (string)$data['date'],
+            'EXPERT_ID'          => $expert->id,
+            'EXPERT_NAME'        => $expert->getFullName(),
+            'CLIENT_ID'          => $client->id,
+            'CLIENT_NAME'        => $client->getFullName() ??  $client->name,
+            'CONSUMPTION_ID'     => $this->data->consumptionId,
+            'CONSUMPTION_NUMBER' => $this->data->consumptionNumber,
+            'AGREEMENT_NUMBER'   => $this->data->agreementNumber,
+            'DATE'               => $this->data->date,
             'DIFFERENCES'        => $differences,
         ];
-
         // Если хоть одна переменная для шаблона не задана, то не отправляем уведомления
-        foreach ($templateData as $key => $tempData) {
+        foreach ($this->templateData as $key => $tempData) {
             if (empty($tempData)) {
-                throw new \Exception("Template Data ({$key}) is empty!", 500);
+                throw new BusinessErrorException("Template Data ({$key}) is empty!");
             }
         }
 
-        $emailFrom = getResellerEmailFrom($resellerId);
+        $result['notificationEmployeeByEmail'] = $this->adminNotification();
+
+        if ($this->notificationType === self::TYPE_CHANGE && !empty($this->data->differencesTo)) {
+            $result['notificationClientByEmail'] = $this->clientEmailNotification($client);
+            $error = '';
+            $result['notificationClientBySms']['isSent'] = $this->clientMobileNotification($client, $error);
+        }
+
+        return $result;
+    }
+
+    protected function adminNotification() {
+        $result = false;
+        $emailFrom = getResellerEmailFrom($this->reseller->id);
         // Получаем email сотрудников из настроек
-        $emails = getEmailsByPermit($resellerId, 'tsGoodsReturn');
+        $emails = getEmailsByPermit($this->reseller->id, 'tsGoodsReturn');
         if (!empty($emailFrom) && count($emails) > 0) {
             foreach ($emails as $email) {
-                MessagesClient::sendMessage([
-                    0 => [ // MessageTypes::EMAIL
-                           'emailFrom' => $emailFrom,
-                           'emailTo'   => $email,
-                           'subject'   => __('complaintEmployeeEmailSubject', $templateData, $resellerId),
-                           'message'   => __('complaintEmployeeEmailBody', $templateData, $resellerId),
-                    ],
-                ], $resellerId, NotificationEvents::CHANGE_RETURN_STATUS);
-                $result['notificationEmployeeByEmail'] = true;
-
-            }
-        }
-
-        // Шлём клиентское уведомление, только если произошла смена статуса
-        if ($notificationType === self::TYPE_CHANGE && !empty($data['differences']['to'])) {
-            if (!empty($emailFrom) && !empty($client->email)) {
-                MessagesClient::sendMessage([
-                    0 => [ // MessageTypes::EMAIL
-                           'emailFrom' => $emailFrom,
-                           'emailTo'   => $client->email,
-                           'subject'   => __('complaintClientEmailSubject', $templateData, $resellerId),
-                           'message'   => __('complaintClientEmailBody', $templateData, $resellerId),
-                    ],
-                ], $resellerId, $client->id, NotificationEvents::CHANGE_RETURN_STATUS, (int)$data['differences']['to']);
-                $result['notificationClientByEmail'] = true;
-            }
-
-            if (!empty($client->mobile)) {
-                $res = NotificationManager::send($resellerId, $client->id, NotificationEvents::CHANGE_RETURN_STATUS, (int)$data['differences']['to'], $templateData, $error);
-                if ($res) {
-                    $result['notificationClientBySms']['isSent'] = true;
-                }
-                if (!empty($error)) {
-                    $result['notificationClientBySms']['message'] = $error;
+                try {
+                    MessagesClient::sendMessage([
+                        MessagesClient::EMAIL => [
+                               'emailFrom' => $emailFrom,
+                               'emailTo'   => $email,
+                               'subject'   => ResellerView::make('complaintEmployeeEmailSubject', $this->templateData, $this->reseller->id),
+                               'message'   => ResellerView::make('complaintEmployeeEmailBody', $this->templateData, $this->reseller->id),
+                        ],
+                    ], $this->reseller->id, NotificationEvents::CHANGE_RETURN_STATUS);
+                    $result = true;
+                } catch(\Exception $e) {
                 }
             }
         }
+        return $result;
+    }
 
+    protected function clientEmailNotification($client) {
+        $result = false;
+        if (!empty($emailFrom) && !empty($client->email)) {
+            MessagesClient::sendMessage([
+                MessagesClient::EMAIL => [
+                       'emailFrom' => $emailFrom,
+                       'emailTo'   => $client->email,
+                       'subject'   => ResellerView::make('complaintClientEmailSubject', $this->templateData, $this->reseller->id),
+                       'message'   => ResellerView::make('complaintClientEmailBody', $this->templateData, $this->reseller->id),
+                ],
+            ], $this->reseller->id, $client->id, NotificationEvents::CHANGE_RETURN_STATUS, $this->data->differencesTo);
+            $result = true;
+        }
+        return $result;
+    }
+
+    protected function clientMobileNotification($client, &$error)
+    {
+        $result = false;
+        if (!empty($client->mobile)) {
+            $res = NotificationManager::send($this->reseller->id, $client->id, NotificationEvents::CHANGE_RETURN_STATUS, $this->data->differencesTo, $this->templateData, $error);
+            if ($res) {
+                $result = true;
+            }
+        }
         return $result;
     }
 }

--- a/php/v2/others.php
+++ b/php/v2/others.php
@@ -73,3 +73,50 @@ class NotificationEvents
     const CHANGE_RETURN_STATUS = 'changeReturnStatus';
     const NEW_RETURN_STATUS    = 'newReturnStatus';
 }
+
+class NotificationData
+{
+    public function __construct(
+        public int $complaintId,
+        public string $complaintNumber,
+        public int $creatorId,
+        public int $expertId,
+        public int $clientId,
+        public int $consumptionId,
+        public string $consumptionNumber,
+        public string $agreementNumber,
+        public string $date,
+        public int $differencesFrom,
+        public int $differencesTo,
+    ){
+    }
+}
+
+class ResellerView
+{
+    public static function make($name, $data, $id) : string {
+        return View::make($name, $data);
+    }
+}
+
+class MessagesClient
+{
+    public const EMAIL = 0;
+    public static function sendMessage(
+        $message, $resellerId, $status
+    ) {
+
+    }
+}
+class NotificationManager {
+    public static function send($resellerId, $clientId, $status , $newState, $data, &$error) {
+
+    }
+}
+
+class BusinessException extends \Exception {
+}
+class BusinessErrorException extends BusinessException {
+
+}
+


### PR DESCRIPTION
 В данном случае реализация паттерна Command (Operation) целью которого является сделать
 непрямым взаимодействие исполнителя (MessagesClient и NotificationManager) и вызывающего класса (контроллера)
 Реализовано не полностью тк :
  - исполнитель лезет в данные запроса Request (а значит привязан к слою контроллера), а также в нем есть HTTP коды,
 которые могут иметь какое-то значение только в рамках http, лучше кидать эксепшены бизнес-логики, 
  уже в слое контроллер их преобразовывать для ответа клииенту, текущее решение снижает гибкость использования операции 
то есть например осуществить данную операцию из командной строки уже невозможно (исправлено)
 - происходит два разных действия с точки зрения бизнеса (Админское уведомление и Клиентское уведомление), что странно (не исправлено)
 Что поправилось
 - вместо входного массива лучше использовать DTO и валидацию и преобразование типов делать на входе. ДТО позволяет поьзоваться автодополнением вместо строковых ключей массива
 - добавил валидацию на входной тип
 - обернул опасную операцию try-catch
 - добавил эксепшены, чтобы оторвать модель от контроллера
 - добавил функции чтобы их название вместо комментариев объясняло какие два действия совершаются (клиентское и админское уведомление)
 И есть некоторые вопросы, оставшиеся неисправленными
 - надо бы валидацию данных (not found for example) унести в контроллер, здесь оставить только бизнес-проверки
 - что надо делать если одному админу письмо ушло, а на втором упало, надо ли слать клиенту
 - типизация ответа операции лучще делать через класс а не массив