### PR TITLE
refactor(task_creator): Clean-up task creator

### DIFF
--- a/golang/main.go
+++ b/golang/main.go
@@ -2,103 +2,80 @@ package main
 
 import (
 	"fmt"
+	"sync"
 	"time"
 )
 
-// ЗАДАНИЕ:
-// * сделать из плохого кода хороший;
-// * важно сохранить логику появления ошибочных тасков;
-// * сделать правильную мультипоточность обработки заданий.
-// Обновленный код отправить через merge-request.
-
-// приложение эмулирует получение и обработку тасков, пытается и получать и обрабатывать в многопоточном режиме
-// В конце должно выводить успешные таски и ошибки выполнены остальных тасков
-
-// A Ttype represents a meaninglessness of our life
-type Ttype struct {
-	id         int
-	cT         string // время создания
-	fT         string // время выполнения
-	taskRESULT []byte
+type Task struct {
+	ID         int
+	CreatedAt  string
+	FinishedAt string
+	Result     []byte
 }
 
 func main() {
-	taskCreturer := func(a chan Ttype) {
-		go func() {
-			for {
-				ft := time.Now().Format(time.RFC3339)
-				if time.Now().Nanosecond()%2 > 0 { // вот такое условие появления ошибочных тасков
-					ft = "Some error occured"
-				}
-				a <- Ttype{cT: ft, id: int(time.Now().Unix())} // передаем таск на выполнение
-			}
-		}()
+	const maxTasks = 10
+	taskChan := make(chan Task, maxTasks)
+	doneTasks := make(chan Task, maxTasks)
+	errorTasks := make(chan error, maxTasks)
+	var wg sync.WaitGroup
+
+	// Task creator
+	go createTasks(taskChan)
+
+	// Task processor
+	for i := 0; i < maxTasks; i++ {
+		wg.Add(1)
+		go processTasks(taskChan, doneTasks, errorTasks, &wg)
 	}
 
-	superChan := make(chan Ttype, 10)
+	// Collect results for a fixed time
+	time.Sleep(3 * time.Second)
+	close(taskChan)
+	wg.Wait()
+	close(doneTasks)
+	close(errorTasks)
 
-	go taskCreturer(superChan)
+	displayResults(doneTasks, errorTasks)
+}
 
-	task_worker := func(a Ttype) Ttype {
-		tt, _ := time.Parse(time.RFC3339, a.cT)
-		if tt.After(time.Now().Add(-20 * time.Second)) {
-			a.taskRESULT = []byte("task has been successed")
+func createTasks(taskChan chan<- Task) {
+	for {
+		task := Task{
+			ID:        int(time.Now().Unix()),
+			CreatedAt: time.Now().Format(time.RFC3339),
+		}
+		if time.Now().Nanosecond()%2 > 0 {
+			task.CreatedAt = "Some error occurred"
+		}
+		taskChan <- task
+		time.Sleep(150 * time.Millisecond)
+	}
+}
+
+func processTasks(taskChan <-chan Task, doneTasks chan<- Task, errorTasks chan<- error, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for task := range taskChan {
+		t, err := time.Parse(time.RFC3339, task.CreatedAt)
+		if err != nil || t.Before(time.Now().Add(-20*time.Second)) {
+			task.Result = []byte("something went wrong")
+			errorTasks <- fmt.Errorf("Task id %d, error: %s", task.ID, task.Result)
 		} else {
-			a.taskRESULT = []byte("something went wrong")
+			task.Result = []byte("task has been succeeded")
+			doneTasks <- task
 		}
-		a.fT = time.Now().Format(time.RFC3339Nano)
+		task.FinishedAt = time.Now().Format(time.RFC3339Nano)
+	}
+}
 
-		time.Sleep(time.Millisecond * 150)
-
-		return a
+func displayResults(doneTasks <-chan Task, errorTasks <-chan error) {
+	fmt.Println("Done tasks:")
+	for task := range doneTasks {
+		fmt.Printf("Task ID: %d, Finished At: %s\n", task.ID, task.FinishedAt)
 	}
 
-	doneTasks := make(chan Ttype)
-	undoneTasks := make(chan error)
-
-	tasksorter := func(t Ttype) {
-		if string(t.taskRESULT[14:]) == "successed" {
-			doneTasks <- t
-		} else {
-			undoneTasks <- fmt.Errorf("Task id %d time %s, error %s", t.id, t.cT, t.taskRESULT)
-		}
-	}
-
-	go func() {
-		// получение тасков
-		for t := range superChan {
-			t = task_worker(t)
-			go tasksorter(t)
-		}
-		close(superChan)
-	}()
-
-	result := map[int]Ttype{}
-	err := []error{}
-	go func() {
-		for r := range doneTasks {
-			go func() {
-				result[r.id] = r
-			}()
-		}
-		for r := range undoneTasks {
-			go func() {
-				err = append(err, r)
-			}()
-		}
-		close(doneTasks)
-		close(undoneTasks)
-	}()
-
-	time.Sleep(time.Second * 3)
-
-	println("Errors:")
-	for r := range err {
-		println(r)
-	}
-
-	println("Done tasks:")
-	for r := range result {
-		println(r)
+	fmt.Println("\nErrors:")
+	for err := range errorTasks {
+		fmt.Println(err)
 	}
 }


### PR DESCRIPTION
Key Changes Made:

- Organized code into functions for clarity.
- Used sync.WaitGroup for managing the lifecycle of goroutines.
- Improved variable and function names for readability.
- Moved the task processing and error handling logic into dedicated functions.
- Fixed a race condition by removing concurrent writes to maps, instead using channels to collect results.